### PR TITLE
swapped blue and green pins for rgb-5050 hello world

### DIFF
--- a/projects/Hello-World/rtl/hello_world.v
+++ b/projects/Hello-World/rtl/hello_world.v
@@ -3,7 +3,7 @@
 
 module top(
   input clk_in,
-  output [2:0] rgb // LED outputs. [0]: Blue, [1]: Red, [2]: Green.
+  output [2:0] rgb // LED outputs. [0]: Green, [1]: Red, [2]: Blue.
 );
 
   wire clk = clk_in; // Directly use the 12 MHz oscillator, no fancy PLL config
@@ -39,9 +39,9 @@ module top(
   ) RGBA_DRIVER (
       .CURREN(1'b1),
       .RGBLEDEN(1'b1),
+      .RGB0PWM(green),
       .RGB1PWM(red),
-      .RGB2PWM(green),
-      .RGB0PWM(blue),
+      .RGB2PWM(blue),      
       .RGB0(rgb[0]),
       .RGB1(rgb[1]),
       .RGB2(rgb[2])

--- a/projects/_common/data/mch2022-proto4.pcf
+++ b/projects/_common/data/mch2022-proto4.pcf
@@ -57,6 +57,6 @@ set_io -nowarn -pullup no  pmod[6]      3  # PMOD9
 set_io -nowarn -pullup no  pmod[7]     46  # PMOD10
 
 # RGB driver
-set_io -nowarn             rgb[0]      39
-set_io -nowarn             rgb[1]      40
-set_io -nowarn             rgb[2]      41
+set_io -nowarn             rgb[0]      39 # green
+set_io -nowarn             rgb[1]      40 # red
+set_io -nowarn             rgb[2]      41 # blue


### PR DESCRIPTION
looks like rgb-5050 datasheet is wrong, causing pins for blue and green are swapped
see https://github.com/badgeteam/mch2022-badge-hardware/issues/88